### PR TITLE
Add Travis CI integration, fix image spacing in docs

### DIFF
--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,15 @@
+language: node_js
+node_js:
+  - '6'
+before_script:
+  - yarn run dist-test
+script:
+  - yarn lint
+  - yarn run test-es6
+  - yarn run test-dist
+  - yarn run check-prettier
+  - yarn run check-docs
+  - yarn cover
+after_success:
+  - npm install -g coveralls
+  - cat coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Convert a single H3 hexagon to a `Polygon` feature
 Convert a set of hexagons to a GeoJSON `Feature` with the set outline(s). The
 feature's geometry type will be either `Polygon` or `MultiPolygon` depending on
 the number of outlines required for the set.
+
 ![h3SetToFeature](./doc-files/h3SetToFeature.png)
 
 **Kind**: static method of [<code>geojson2h3</code>](#module_geojson2h3)  
@@ -111,6 +112,7 @@ the number of outlines required for the set.
 ### geojson2h3.h3SetToMultiPolygonFeature(hexagons, [properties]) ⇒ <code>Feature</code>
 Convert a set of hexagons to a GeoJSON `MultiPolygon` feature with the
 outlines of each individual hexagon.
+
 ![h3SetToMultiPolygonFeature](./doc-files/h3SetToFeatureCollection.png)
 
 **Kind**: static method of [<code>geojson2h3</code>](#module_geojson2h3)  
@@ -129,6 +131,7 @@ outlines of each individual hexagon.
 ### geojson2h3.h3SetToFeatureCollection(hexagons, [getProperties]) ⇒ <code>FeatureCollection</code>
 Convert a set of hexagons to a GeoJSON `FeatureCollection` with each hexagon
 in a separate `Polygon` feature with optional properties.
+
 ![h3SetToFeatureCollection](./doc-files/h3SetToFeatureCollection.png)
 
 **Kind**: static method of [<code>geojson2h3</code>](#module_geojson2h3)  

--- a/src/geojson2h3.js
+++ b/src/geojson2h3.js
@@ -192,6 +192,7 @@ function h3ToFeature(hexAddress, properties = {}) {
  * Convert a set of hexagons to a GeoJSON `Feature` with the set outline(s). The
  * feature's geometry type will be either `Polygon` or `MultiPolygon` depending on
  * the number of outlines required for the set.
+ *
  * ![h3SetToFeature](./doc-files/h3SetToFeature.png)
  * @static
  * @param  {String[]} hexagons   Hexagon addresses
@@ -218,6 +219,7 @@ function h3SetToFeature(hexagons, properties = {}) {
 /**
  * Convert a set of hexagons to a GeoJSON `MultiPolygon` feature with the
  * outlines of each individual hexagon.
+ *
  * ![h3SetToMultiPolygonFeature](./doc-files/h3SetToFeatureCollection.png)
  * @static
  * @param  {String[]} hexagons   Hexagon addresses
@@ -242,6 +244,7 @@ function h3SetToMultiPolygonFeature(hexagons, properties = {}) {
 /**
  * Convert a set of hexagons to a GeoJSON `FeatureCollection` with each hexagon
  * in a separate `Polygon` feature with optional properties.
+ *
  * ![h3SetToFeatureCollection](./doc-files/h3SetToFeatureCollection.png)
  * @static
  * @param  {String[]} hexagons  Hexagon addresses


### PR DESCRIPTION
- Adds `.travis.yml` with Coveralls integration
- Fixes a spacing issue that wasn't worth its own PR