### PR TITLE
Move .yarnrc to .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry = https://registry.npmjs.org
+always-auth = false

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
---registry "https://registry.npmjs.org"


### PR DESCRIPTION
This is slightly Uber-specific, but putting the correct registry in `.yarnrc` means it's ignored by npm, e.g. on `npm publish`, while `yarn` falls back to `.npmrc` if no `.yarnrc` is found. So using `.npmrc` means both `yarn` and `npm` get the correct settings.