### PR TITLE
Update h3-js to 3.1.1, add benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geojson2h3",
   "description": "Conversion utilities between H3 indexes and GeoJSON",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Nick Rabinowitz <nickr@uber.com>",
   "keywords": [
     "h3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@turf/boolean-clockwise": "^6.0.1",
     "@turf/boolean-point-in-polygon": "^6.0.1",
+    "benchmark": "^2.1.4",
     "h3-js": "^3.0.1"
   },
   "devDependencies": {
@@ -35,17 +36,18 @@
   "scripts": {
     "lint": "eslint src test",
     "cover": "istanbul cover --report lcov --report html -- test/index.js",
-    "test": "yarn run dist-test && yarn lint && yarn run test-es6 && yarn run test-dist",
+    "test": "yarn dist-test && yarn lint && yarn test-es6 && yarn test-dist",
     "test-raw": "node test/index.js",
     "test-es6": "yarn test-raw | faucet",
     "test-dist": "node dist/test/index.js | faucet",
     "check-prettier": "yarn prettier && git diff --exit-code",
     "check-docs": "yarn build-docs && git diff --exit-code",
     "build-docs": "jsdoc2md --global-index-format grouped --separators --template doc-files/README.md.tmpl src/geojson2h3.js > README.md",
-    "dist": "yarn run dist-clean && buble -i src -o dist/src",
+    "dist": "yarn dist-clean && buble -i src -o dist/src",
     "dist-clean": "rm -rf dist && mkdir dist",
-    "dist-test": "yarn run dist && buble -i test -o dist/test",
-    "prepublish": "yarn run dist",
+    "dist-test": "yarn dist && buble -i test -o dist/test",
+    "benchmarks": "yarn dist-test && node dist/test/benchmarks.js",
+    "prepublish": "yarn dist",
     "prettier": "prettier --write --single-quote --no-bracket-spacing --print-width=100 'src/**/*.js' 'test/**/*.js'"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
   "main": "index.js",
   "es2015": "lib/geojson2h3.js",
   "dependencies": {
-    "@turf/boolean-clockwise": "^6.0.1",
-    "@turf/boolean-point-in-polygon": "^6.0.1",
-    "benchmark": "^2.1.4",
-    "h3-js": "^3.0.1"
+    "h3-js": "^3.1.1"
   },
   "devDependencies": {
+    "benchmark": "^2.1.4",
     "buble": "^0.19.3",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",

--- a/test/benchmarks.js
+++ b/test/benchmarks.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Uber Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* eslint-env node */
+/* eslint-disable no-console */
+const Benchmark = require('benchmark');
+const h3 = require('h3-js');
+const geojson2h3 = require('../src/geojson2h3');
+
+const suite = new Benchmark.Suite();
+
+// fixtures
+
+const h3Index = '89283080ddbffff';
+const ring50 = h3.kRing(h3Index, 50);
+const ring50Feature = geojson2h3.h3SetToFeature(ring50, 9);
+const ring50Donuts = h3
+    .kRing(h3Index, 10)
+    .concat(h3.kRing(h3, 20))
+    .concat(h3.kRing(h3, 30))
+    .concat(h3.kRing(h3, 40))
+    .concat(h3.kRing(h3, 50));
+const ring50DonutsFeature = geojson2h3.h3SetToFeature(ring50Donuts, 9);
+
+// add tests
+
+suite.add('h3SetToFeature - ring50', () => {
+    geojson2h3.h3SetToFeature(ring50);
+});
+
+suite.add('h3SetToFeature - ring50Donuts', () => {
+    geojson2h3.h3SetToFeature(ring50Donuts);
+});
+
+suite.add('featureToH3Set - ring50', () => {
+    geojson2h3.featureToH3Set(ring50Feature, 9);
+});
+
+suite.add('featureToH3Set - ring50Donuts', () => {
+    geojson2h3.featureToH3Set(ring50DonutsFeature, 9);
+});
+
+// add listeners
+suite
+    .on('cycle', event => {
+        console.log(String(event.target));
+    })
+    // run async
+    .run({async: true});

--- a/test/geojson2h3.spec.js
+++ b/test/geojson2h3.spec.js
@@ -167,7 +167,7 @@ test('Symmetrical - One hexagon', assert => {
             coordinates: [
                 // Note that this is a little brittle; iterating from any
                 // starting vertex would be correct
-                [...vertices.slice(2, 6), ...vertices.slice(0, 3)]
+                [...vertices]
             ]
         }
     };
@@ -185,6 +185,8 @@ test('Symmetrical - Two hexagons', assert => {
             type: 'Polygon',
             coordinates: [
                 [
+                    [-122.42778275313196, 37.775989518837726],
+                    [-122.42652309807923, 37.77448508566524],
                     [-122.42419231791126, 37.7746633251758],
                     [-122.42312112449315, 37.776346021077586],
                     [-122.42438078060647, 37.77785047757876],
@@ -193,9 +195,7 @@ test('Symmetrical - Two hexagons', assert => {
                     [-122.4303021418057, 37.778998255103545],
                     [-122.4313731964829, 37.77731555898803],
                     [-122.43011350268344, 37.77581120251896],
-                    [-122.42778275313196, 37.775989518837726],
-                    [-122.42652309807923, 37.77448508566524],
-                    [-122.42419231791126, 37.7746633251758]
+                    [-122.42778275313196, 37.775989518837726]
                 ]
             ]
         }
@@ -539,14 +539,19 @@ test('h3SetToFeature - multi donut', assert => {
     assert.end();
 });
 
-test('h3SetToFeature - nested donut throws', assert => {
+test('h3SetToFeature - nested donut', assert => {
     const middle = '89283082877ffff';
     const hexagons = h3.hexRing(middle, 1).concat(h3.hexRing(middle, 3));
-    assert.throws(
-        () => h3SetToFeature(hexagons),
-        /Unsupported MultiPolygon topology/,
-        'throws expected error'
-    );
+    const feature = h3SetToFeature(hexagons);
+    const coords = feature.geometry.coordinates;
+
+    assert.strictEqual(coords.length, 2, 'expected polygon count');
+    assert.strictEqual(coords[0].length, 2, 'expected loop count for p1');
+    assert.strictEqual(coords[1].length, 2, 'expected loop count for p2');
+    assert.strictEqual(coords[0][0].length, 6 * 3 + 1, 'expected outer coord count p1');
+    assert.strictEqual(coords[0][1].length, 7, 'expected inner coord count p1');
+    assert.strictEqual(coords[1][0].length, 6 * 7 + 1, 'expected outer coord count p2');
+    assert.strictEqual(coords[1][1].length, 6 * 5 + 1, 'expected inner coord count p2');
 
     assert.end();
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,30 +2,6 @@
 # yarn lockfile v1
 
 
-"@turf/boolean-clockwise@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/@turf/boolean-clockwise/-/boolean-clockwise-6.0.1.tgz#87261f8ed1e03671e39b6ebd138388de0e6aca4b"
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
-"@turf/boolean-point-in-polygon@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.0.1.tgz#5836677afd77d2ee391af0056a0c29b660edfa32"
-  dependencies:
-    "@turf/helpers" "6.x"
-    "@turf/invariant" "6.x"
-
-"@turf/helpers@6.x":
-  version "6.1.4"
-  resolved "https://registry.npmjs.org/@turf/helpers/-/helpers-6.1.4.tgz#d6fd7ebe6782dd9c87dca5559bda5c48ae4c3836"
-
-"@turf/invariant@6.x":
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/@turf/invariant/-/invariant-6.1.2.tgz#6013ed6219f9ac2edada9b31e1dfa5918eb0a2f7"
-  dependencies:
-    "@turf/helpers" "6.x"
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -742,9 +718,9 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
-h3-js@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/h3-js/-/h3-js-3.0.2.tgz#99a7d3251a6ffb21d8d885f1e6ecf2fd96248f69"
+h3-js@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/h3-js/-/h3-js-3.1.1.tgz#5e62994c46ee4053327cd437f4fde4fe3430bf3d"
 
 handlebars@^4.0.1, handlebars@^4.0.11:
   version "4.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,6 +172,13 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+benchmark@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 bluebird@~3.5.0:
   version "3.5.1"
   resolved "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
@@ -1186,6 +1193,10 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
+
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 pluralize@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
* Updates `h3-js` to 3.1.1, bringing in multipolygon normalization from the core library. This allows us to drop dependencies on Turf packages for clockwise and point-in-poly algorithms.
* Bumps library version to 1.0.1
* Updates tests to match new output and ability to handle nested polygon topologies.
* Adds benchmarks, mostly because I was curious whether the C normalization would speed things up. Answer: only slightly in the cases I tried.

Benchmarks, before bumping library:
```
h3SetToFeature - ring50 x 13.69 ops/sec ±0.61% (37 runs sampled)
h3SetToFeature - ring50Donuts x 275 ops/sec ±0.74% (81 runs sampled)
featureToH3Set - ring50 x 5.59 ops/sec ±2.04% (18 runs sampled)
featureToH3Set - ring50Donuts x 316 ops/sec ±1.08% (79 runs sampled)
```
After bumping library and removing JS normalization:
```
h3SetToFeature - ring50 x 14.12 ops/sec ±0.72% (38 runs sampled)
h3SetToFeature - ring50Donuts x 283 ops/sec ±0.80% (84 runs sampled)
featureToH3Set - ring50 x 4.94 ops/sec ±2.74% (17 runs sampled)
featureToH3Set - ring50Donuts x 305 ops/sec ±0.98% (81 runs sampled)
```