### PR TITLE
Release 1.3.2: Fix release, take 2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,5 @@
 .*
 *.log
-src/
 test/
 coverage/
 node_modules/

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geojson2h3",
   "description": "Conversion utilities between H3 indexes and GeoJSON",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "author": "Nick Rabinowitz <nickr@uber.com>",
   "keywords": [
     "h3",


### PR DESCRIPTION
It looks like the behavior of `.npmignore` has changed, and listing `src/` was also ignoring `dist/src`. This fixes `.npmignore` and bumps the patch version. Verified via `npm publish --dry-run`, which now shows the right files.

Closes https://github.com/uber/geojson2h3/issues/45