### PR TITLE
ci: set read-only token permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Test Node ${{ matrix.node_version }}


### PR DESCRIPTION
Restricts the GITHUB_TOKEN to `contents: read` on the test workflow. The workflow only needs to check out code and run tests. Limiting token scope follows standard security hardening for GitHub Actions.